### PR TITLE
Disable auto init altering default http transport

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -40,6 +40,7 @@ the cslb.Enable() function, i.e.:
 
 	func main() {
 	        myTransport := http.Transport{...}
+					cslb.Setup()
 	        cslb.Enable(myTransport)
 	        client := &http.Client{Transport: myTransport}
 	        resp, err := client.Get("http://mydomain/resource")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/markdingo/cslb
+module github.com/rudderlabs/cslb
 
 go 1.21


### PR DESCRIPTION
## Description of the change

* Stops auto enabling of Cslb for default http transport on package import.
* Adds new environment variable cslb_auto_init_enabled to use the previous behaviour of auto initialisation
* library users now need to explicitly call Setup and enable Cslb for any http transport.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
